### PR TITLE
Filtering using only butterworth

### DIFF
--- a/niphlem/clean.py
+++ b/niphlem/clean.py
@@ -15,9 +15,9 @@ def butter_filter(data, *, fs, low_pass=None, high_pass=None, order=5):
     fs : real
         sampling frequency (Hz)
     low_pass : real
-        frequency below filtering data (Hz)
+        frequency below passing data (Hz)
     high_pass : real
-        frequency above filtering data (Hz)
+        frequency above passing data (Hz)
     order : int
         filter order (will be rounded up to even integer)
 

--- a/niphlem/clean.py
+++ b/niphlem/clean.py
@@ -60,6 +60,7 @@ def butter_filter(data, *, fs, low_pass=None, high_pass=None, order=5):
     return sosfiltfilt(sos, data)
 
 
+# TODO: Ask Andrew about the use of this function
 def filter_signals(meta, sig_file, show_signals=False):
     """
     Applies filters to data and write to new npy file
@@ -88,18 +89,18 @@ def filter_signals(meta, sig_file, show_signals=False):
     filtered_signal = np.zeros_like(signal)
     filtered_signal[:, 0] = signal[:, 0]
     filtered_signal[:, -2] = butter_filter(signal[:, -2],
-                                           card_range[0],
-                                           card_range[1],
-                                           sf)
+                                           high_pass=card_range[0],
+                                           low_pass=card_range[1],
+                                           fs=sf)
     filtered_signal[:, -1] = butter_filter(signal[:, -1],
-                                           resp_range[0],
-                                           resp_range[1],
-                                           sf)
+                                           high_pass=resp_range[0],
+                                           low_pass=resp_range[1],
+                                           fs=sf)
     # note: factor of 5 is empirical
     for i in range(nch):
-        filtered_signal[:, i] = gaussian_lowpass_filter(signal[:, i],
-                                                        sf,
-                                                        card_range[1])
+        filtered_signal[:, i] = butter_filter(signal[:, i],
+                                              fs=sf,
+                                              low_pass=card_range[1])
     # save filtered signal to filtered_signal.npy
     np.save('filtered_signal', filtered_signal)
 

--- a/niphlem/clean.py
+++ b/niphlem/clean.py
@@ -1,9 +1,10 @@
 import numpy as np
 import json
 import matplotlib.pyplot as mpl
+import warnings
 
 
-def butter_bandpass_filter(data, lowcut, highcut, fs, order=5):
+def butter_filter(data, *, fs, low_pass=None, high_pass=None, order=5):
     """
     Applies Butterworth bandpass double filter (to minimize shift).
 
@@ -11,59 +12,52 @@ def butter_bandpass_filter(data, lowcut, highcut, fs, order=5):
     ---------
     data : vector
         signal to be filtered
-    lowcut : real
-        lowpass cutoff frequency (Hz)
-    highcut : real
-        highpass cutoff frequency (Hz)
     fs : real
         sampling frequency (Hz)
+    low_pass : real
+        frequency below filtering data (Hz)
+    high_pass : real
+        frequency above filtering data (Hz)
     order : int
         filter order (will be rounded up to even integer)
 
     Returns
     -------
-    bandpass filtered signal
+    filtered signal
     """
 
-    # fs, lowcut and highcut are in frequency units (Hz)
     from scipy.signal import (sosfiltfilt, butter)
 
+    if low_pass is None and high_pass is None:
+        # TODO: Maybe we could delete this warning message
+        warnings.warn("No low_pass or high_pass filtered supplied,"
+                      " so no filtering was performed")
+        return data
+
+    fs = float(fs)
     nyq = 0.5 * fs
-    low = lowcut / nyq
-    high = highcut / nyq
+
+    if high_pass and low_pass:
+        lowcut = float(high_pass)/nyq
+        highcut = float(low_pass)/nyq
+        Wn = [lowcut, highcut]
+        btype = 'band'
+    elif high_pass:
+        lowcut = float(high_pass)/nyq
+        Wn = lowcut
+        btype = 'highpass'
+    else:
+        highcut = float(low_pass)/nyq
+        Wn = highcut
+        btype = 'lowpass'
+
     sos = butter(N=np.ceil(order/2),
-                 Wn=[low, high],
+                 Wn=Wn,
                  analog=False,
-                 btype='band',
+                 btype=btype,
                  output='sos')
 
     return sosfiltfilt(sos, data)
-
-
-def gaussian_lowpass_filter(data, fs, cut):
-    """
-    Applies Gaussian lowpass filter.
-
-    Parameters
-    ---------
-    data : array
-        signal to be filtered
-    fs : real
-        sampling frequency (Hz)
-    cut : real
-        cutoff frequency (Hz)
-
-    Returns
-    -------
-    lowpass filtered signal
-    """
-
-    from scipy.ndimage import gaussian_filter1d
-
-    sigma = fs/(2*np.pi*cut)
-    signal = gaussian_filter1d(data, sigma)
-
-    return signal
 
 
 def filter_signals(meta, sig_file, show_signals=False):
@@ -93,14 +87,14 @@ def filter_signals(meta, sig_file, show_signals=False):
     # filter
     filtered_signal = np.zeros_like(signal)
     filtered_signal[:, 0] = signal[:, 0]
-    filtered_signal[:, -2] = butter_bandpass_filter(signal[:, -2],
-                                                    card_range[0],
-                                                    card_range[1],
-                                                    sf)
-    filtered_signal[:, -1] = butter_bandpass_filter(signal[:, -1],
-                                                    resp_range[0],
-                                                    resp_range[1],
-                                                    sf)
+    filtered_signal[:, -2] = butter_filter(signal[:, -2],
+                                           card_range[0],
+                                           card_range[1],
+                                           sf)
+    filtered_signal[:, -1] = butter_filter(signal[:, -1],
+                                           resp_range[0],
+                                           resp_range[1],
+                                           sf)
     # note: factor of 5 is empirical
     for i in range(nch):
         filtered_signal[:, i] = gaussian_lowpass_filter(signal[:, i],
@@ -130,11 +124,10 @@ def filter_signals(meta, sig_file, show_signals=False):
 
 def _transform_filter(data,
                       *,
-                      transform,
-                      filtering,
-                      high_pass,
-                      low_pass,
-                      sampling_rate):
+                      sampling_rate,
+                      transform=None,
+                      high_pass=None,
+                      low_pass=None):
 
     # Guarantee original data is not overwritten
     data = data.copy()
@@ -151,18 +144,10 @@ def _transform_filter(data,
         # Only demean
         data = data - np.mean(data)
 
-    if filtering == "butter":
-        # TODO: Add more flexible butter filter, not only bandpass?
-        # high_pass == frequency above to clean, then here is the lower range,
-        # low_pass == frequency below to clean, then here is the higher range.
-        data = butter_bandpass_filter(data,
-                                      lowcut=high_pass,
-                                      highcut=low_pass,
-                                      fs=sampling_rate)
-    elif filtering == "gaussian":
-        data = gaussian_lowpass_filter(data,
-                                       fs=sampling_rate,
-                                       cut=low_pass)
+    data = butter_filter(data,
+                         high_pass=high_pass,
+                         low_pass=low_pass,
+                         fs=sampling_rate)
     return data
 
 
@@ -177,4 +162,3 @@ def zscore(x, axis=1, nan_omit=True):
 
     zscores = (x - mean(x))/std(x)
     return zscores
-  

--- a/niphlem/models.py
+++ b/niphlem/models.py
@@ -25,10 +25,8 @@ class BasePhysio(BaseEstimator):
         This is needed for filtering to define the nyquist frequency.
     t_r : float
         Repetition time for the scanner (the usual T_R) in secs.
-    transform : {"mean", "zscore", "abs"}, optional
-        Transform data before filtering. The default is "mean".
-    filtering : {"butter", "gaussian", None}, optional
-        Filtering operation to perform. The default is None.
+    transform : {"demean", "zscore", "abs"}, optional
+        Transform data before filtering. The default is "demean".
     high_pass : float, optional
         High-pass filtering frequency (in Hz). Only if filtering option
         is not None. The default is None.
@@ -48,7 +46,7 @@ class BasePhysio(BaseEstimator):
                  *,
                  physio_rate,
                  t_r,
-                 transform="mean",
+                 transform="demean",
                  filtering=None,
                  high_pass=None,
                  low_pass=None,
@@ -58,7 +56,6 @@ class BasePhysio(BaseEstimator):
         self.physio_rate = physio_rate
         self.t_r = t_r
         self.transform = transform
-        self.filtering = filtering
         self.high_pass = high_pass
         self.low_pass = low_pass
         self.columns = columns
@@ -102,7 +99,6 @@ class BasePhysio(BaseEstimator):
         signal_prep = parallel(
             delayed(_transform_filter)(data=s,
                                        transform=self.transform,
-                                       filtering=self.filtering,
                                        high_pass=self.high_pass,
                                        low_pass=self.low_pass,
                                        sampling_rate=self.physio_rate)
@@ -146,27 +142,25 @@ class BasePhysio(BaseEstimator):
         else:
             time_physio = np.arange(signal.shape[0])*1/self.physio_rate
 
-        if self.transform not in ["mean", "zscore", "abs"]:
+        if self.transform not in ["demean", "zscore", "abs"]:
             raise ValueError(f"'{self.transform}' transform option passed, "
                              "but only 'mean' (default), 'zscore' or 'abs' "
                              "are allowed."
                              )
-        if self.filtering not in [None, "butter", "gaussian"]:
-            raise ValueError(f"'{self.filtering}' filtering option passed, "
-                             "but only None (default), 'butter' or 'gaussian' "
-                             "are allowed."
-                             )
-        if self.filtering == "butter":
-            if (self.high_pass is None) or (self.low_pass is None):
-                raise ValueError("Butterworth bandapss selected, but "
-                                 "either high_pass or low_pass is missing."
-                                 )
-        elif self.filtering == "gaussian":
-            if self.low_pass is None:
-                raise ValueError("gaussian lowpass selected, but "
-                                 "low_pass argument is missing."
-                                 )
-
+        if self.high_pass:
+            try:
+                float(self.high_pass)
+            except ValueError:
+                raise ValueError(f" '{self.high_pass}' was provided "
+                                 "as highpass frequency, but it should "
+                                 "be a number")
+        if self.low_pass:
+            try:
+                float(self.low_pass)
+            except ValueError:
+                raise ValueError(f" '{self.low_pass}' was provided "
+                                 "as lowpass frequency, but it should "
+                                 "be a number")
         # Decide how to handle data and loop through
         if self.columns:
             if self.columns == "mean":
@@ -210,8 +204,8 @@ class RetroicorPhysio(BasePhysio):
         Fourier expansion for phases. If int, the fourier expansion is
         performed to that order, starting from 1. If an array is provided,
         each element will multiply the phases.
-    transform : {"mean", "zscore", "abs"}, optional
-        Transform data before filtering. The default is "mean".
+    transform : {"demean", "zscore", "abs"}, optional
+        Transform data before filtering. The default is "demean".
     filtering : {"butter", "gaussian", None}, optional
         Filtering operation to perform. The default is None.
     high_pass : float, optional
@@ -236,7 +230,7 @@ class RetroicorPhysio(BasePhysio):
                  delta,
                  peak_rise=0.5,
                  order=1,
-                 transform="mean",
+                 transform="demean",
                  filtering=None,
                  high_pass=None,
                  low_pass=None,
@@ -347,10 +341,8 @@ class RVPhysio(BasePhysio):
     time_window : float
         Time window (in secs) around the T_R from which computing variations
         (standard deviation of signal). The default is 6 secs.
-    transform : {"mean", "zscore", "abs"}, optional
-        Transform data before filtering. The default is "mean".
-    filtering : {"butter", "gaussian", None}, optional
-        Filtering operation to perform. The default is None.
+    transform : {"demean", "zscore", "abs"}, optional
+        Transform data before filtering. The default is "demean".
     high_pass : float, optional
         High-pass filtering frequency (in Hz). Only if filtering option
         is not None. The default is None.
@@ -371,8 +363,7 @@ class RVPhysio(BasePhysio):
                  physio_rate,
                  t_r,
                  time_window=6.0,
-                 transform="mean",
-                 filtering=None,
+                 transform="demean",
                  high_pass=None,
                  low_pass=None,
                  columns=None,
@@ -383,7 +374,6 @@ class RVPhysio(BasePhysio):
         super().__init__(physio_rate=physio_rate,
                          t_r=t_r,
                          transform=transform,
-                         filtering=filtering,
                          high_pass=high_pass,
                          low_pass=low_pass,
                          columns=columns,
@@ -472,10 +462,8 @@ class HVPhysio(BasePhysio):
     time_window : float
         Time window (in secs) around the T_R from which computing variations
         (time differences between signal events ). The default is 6 secs.
-    transform : {"mean", "zscore", "abs"}, optional
-        Transform data before filtering. The default is "mean".
-    filtering : {"butter", "gaussian", None}, optional
-        Filtering operation to perform. The default is None.
+    transform : {"demean", "zscore", "abs"}, optional
+        Transform data before filtering. The default is "demean".
     high_pass : float, optional
         High-pass filtering frequency (in Hz). Only if filtering option
         is not None. The default is None.
@@ -498,8 +486,7 @@ class HVPhysio(BasePhysio):
                  delta,
                  peak_rise=0.5,
                  time_window=6.0,
-                 transform="mean",
-                 filtering=None,
+                 transform="demean",
                  high_pass=None,
                  low_pass=None,
                  columns=None,
@@ -512,7 +499,6 @@ class HVPhysio(BasePhysio):
         super().__init__(physio_rate=physio_rate,
                          t_r=t_r,
                          transform=transform,
-                         filtering=filtering,
                          high_pass=high_pass,
                          low_pass=low_pass,
                          columns=columns,
@@ -604,10 +590,8 @@ class DownsamplePhysio(BasePhysio):
         This is needed for filtering to define the nyquist frequency.
     t_r : float
         Repetition time for the scanner (the usual T_R) in secs.
-    transform : {"mean", "zscore", "abs"}, optional
-        Transform data before filtering. The default is "mean".
-    filtering : {"butter", "gaussian", None}, optional
-        Filtering operation to perform. The default is None.
+    transform : {"demean", "zscore", "abs"}, optional
+        Transform data before filtering. The default is "demean".
     high_pass : float, optional
         High-pass filtering frequency (in Hz). Only if filtering option
         is not None. The default is None.
@@ -639,8 +623,7 @@ class DownsamplePhysio(BasePhysio):
                  *,
                  physio_rate,
                  t_r,
-                 transform="mean",
-                 filtering=None,
+                 transform="demean",
                  high_pass=None,
                  low_pass=None,
                  columns=None,
@@ -650,7 +633,6 @@ class DownsamplePhysio(BasePhysio):
         self.physio_rate = physio_rate
         self.t_r = t_r
         self.transform = transform
-        self.filtering = filtering
         self.high_pass = high_pass
         self.low_pass = low_pass
         self.columns = columns

--- a/niphlem/models.py
+++ b/niphlem/models.py
@@ -161,6 +161,12 @@ class BasePhysio(BaseEstimator):
                 raise ValueError(f" '{self.low_pass}' was provided "
                                  "as lowpass frequency, but it should "
                                  "be a number")
+        if self.high_pass and self.low_pass:
+            if float(self.high_pass) > float(self.low_pass):
+                raise ValueError("high pass frequency should be lower "
+                                 "than the low pass frequency for a "
+                                 "bandpass filtering"
+                                 )
         # Decide how to handle data and loop through
         if self.columns:
             if self.columns == "mean":

--- a/niphlem/tests/test_models.py
+++ b/niphlem/tests/test_models.py
@@ -53,6 +53,16 @@ def test_initial_checks():
     assert exc_info.type is ValueError
     print(f"we have passed the test: {exc_info.value.args[0]}")
 
+    # Error because high_pass freq is greater than low_pass frequency
+    test_physio = TestPhysio(physio_rate=400, t_r=2.0, delta=200,
+                             high_pass=2, low_pass=1)
+    with pytest.raises(ValueError) as exc_info:
+        test_physio.compute_regressors(signal,
+                                       time_scan,
+                                       time_physio=time_scan)
+    assert exc_info.type is ValueError
+    print(f"we have passed the test: {exc_info.value.args[0]}")
+
     # This should give an error because we are passing a not numeric column
     test_physio = TestPhysio(physio_rate=400, t_r=2.0, delta=200,
                              columns=[1, 2, "dog"])

--- a/niphlem/tests/test_models.py
+++ b/niphlem/tests/test_models.py
@@ -33,6 +33,26 @@ def test_initial_checks():
     assert exc_info.type is ValueError
     print(f"we have passed the test: {exc_info.value.args[0]}")
 
+    # This should give an error because a not numeric low_pass freq is used
+    test_physio = TestPhysio(physio_rate=400, t_r=2.0, delta=200,
+                             low_pass="a string")
+    with pytest.raises(ValueError) as exc_info:
+        test_physio.compute_regressors(signal,
+                                       time_scan,
+                                       time_physio=time_scan)
+    assert exc_info.type is ValueError
+    print(f"we have passed the test: {exc_info.value.args[0]}")
+
+    # This should give an error because a not numeric high_pass freq is used
+    test_physio = TestPhysio(physio_rate=400, t_r=2.0, delta=200,
+                             high_pass="a string")
+    with pytest.raises(ValueError) as exc_info:
+        test_physio.compute_regressors(signal,
+                                       time_scan,
+                                       time_physio=time_scan)
+    assert exc_info.type is ValueError
+    print(f"we have passed the test: {exc_info.value.args[0]}")
+
     # This should give an error because we are passing a not numeric column
     test_physio = TestPhysio(physio_rate=400, t_r=2.0, delta=200,
                              columns=[1, 2, "dog"])


### PR DESCRIPTION
This pull request modifies the code to just have a butterworth as filter. Thus, this can now perform lowpass, highpass and bandpass filtering, depending on the frequencies provided by the user. As a consequence, the old gaussian kernel filter has been removed. The rest of the code has been adapted to this new change.

Also, I have changed the default transformation in the models from "mean" to "demean", as suggested by Andrew and that I think it's more informative.