### PR TITLE
peak correction procedure to models

### DIFF
--- a/niphlem/events.py
+++ b/niphlem/events.py
@@ -79,19 +79,26 @@ def compute_max_events(signal, peak_rise, delta):
 
 def correct_anomalies(peaks, alpha=0.05, save_name=''):
     """
-    Outlier detection (Grubb's test) and removal
+    Outlier peak detection (Grubb's test) and removal.
+
     Parameters
     ----------
-    peak_diffs : array
-        vector of peak-to-peak distances
+    peaks : array
+        vector of peak locations
     alpha : real
         significance level for Grubb's test
     save_name : str
         filename to save peaks as to, empty does not save
+
     Results
     -------
-    peaks : array
-        vector of peak locations
+    corrected_peaks2 : array
+        vector of corrected peak locations
+    max_indices : array
+	indices of original peaks marked as too slow
+    min_indices : array
+	indices of original peaks marked as too fast
+
     """
 
     from outliers import smirnov_grubbs as grubbs

--- a/niphlem/models.py
+++ b/niphlem/models.py
@@ -28,11 +28,9 @@ class BasePhysio(BaseEstimator):
     transform : {"demean", "zscore", "abs"}, optional
         Transform data before filtering. The default is "demean".
     high_pass : float, optional
-        High-pass filtering frequency (in Hz). Only if filtering option
-        is not None. The default is None.
+        High-pass filtering frequency (in Hz). The default is None.
     low_pass : float, optional
-        Low-pass filtering frequency (in Hz). Only if filtering option
-        is not None. The default is None.
+        Low-pass filtering frequency (in Hz). The default is None.
     columns : List or array of n_channels elements, "mean" or None, optional
         It describes how to handle input signal channels. If a list, it will
         weight each channel and take the dot product. If "mean",
@@ -212,19 +210,18 @@ class RetroicorPhysio(BasePhysio):
         each element will multiply the phases.
     transform : {"demean", "zscore", "abs"}, optional
         Transform data before filtering. The default is "demean".
-    filtering : {"butter", "gaussian", None}, optional
-        Filtering operation to perform. The default is None.
     high_pass : float, optional
-        High-pass filtering frequency (in Hz). Only if filtering option
-        is not None. The default is None.
+        High-pass filtering frequency (in Hz). The default is None.
     low_pass : float, optional
-        Low-pass filtering frequency (in Hz). Only if filtering option
-        is not None. The default is None.
+        Low-pass filtering frequency (in Hz). The default is None.
     columns : List or array of n_channels elements, "mean" or None, optional
         It describes how to handle input signal channels. If a list, it will
         weight each channel and take the dot product. If "mean",
         the average across the channels. If None, it will consider each
         channel separately. The default is None.
+    peak_correct : bool, optional
+	Whether to apply an automatic Grubbs' test for peak outlier
+        correction. The default is True.
     n_jobs : int, optional
         Number of jobs to consider in parallel. The default is 1.
     """
@@ -356,11 +353,9 @@ class RVPhysio(BasePhysio):
     transform : {"demean", "zscore", "abs"}, optional
         Transform data before filtering. The default is "demean".
     high_pass : float, optional
-        High-pass filtering frequency (in Hz). Only if filtering option
-        is not None. The default is None.
+        High-pass filtering frequency (in Hz). The default is None.
     low_pass : float, optional
-        Low-pass filtering frequency (in Hz). Only if filtering option
-        is not None. The default is None.
+        Low-pass filtering frequency (in Hz). The default is None.
     columns : List or array of n_channels elements, "mean" or None, optional
         It describes how to handle input signal channels. If a list, it will
         weight each channel and take the dot product. If "mean",
@@ -477,16 +472,17 @@ class HVPhysio(BasePhysio):
     transform : {"demean", "zscore", "abs"}, optional
         Transform data before filtering. The default is "demean".
     high_pass : float, optional
-        High-pass filtering frequency (in Hz). Only if filtering option
-        is not None. The default is None.
+        High-pass filtering frequency (in Hz). The default is None.
     low_pass : float, optional
-        Low-pass filtering frequency (in Hz). Only if filtering option
-        is not None. The default is None.
+        Low-pass filtering frequency (in Hz).  The default is None.
     columns : List or array of n_channels elements, "mean" or None, optional
         It describes how to handle input signal channels. If a list, it will
         weight each channel and take the dot product. If "mean",
         the average across the channels. If None, it will consider each
         channel separately. The default is None.
+    peak_correct : bool, optional
+	Whether to apply an automatic Grubbs' test for peak outlier
+        correction. The default is True.
     n_jobs : int, optional
         Number of jobs to consider in parallel. The default is 1.
     """
@@ -612,11 +608,9 @@ class DownsamplePhysio(BasePhysio):
     transform : {"demean", "zscore", "abs"}, optional
         Transform data before filtering. The default is "demean".
     high_pass : float, optional
-        High-pass filtering frequency (in Hz). Only if filtering option
-        is not None. The default is None.
+        High-pass filtering frequency (in Hz). The default is None.
     low_pass : float, optional
-        Low-pass filtering frequency (in Hz). Only if filtering option
-        is not None. The default is None.
+        Low-pass filtering frequency (in Hz). The default is None.
     columns : List or array of n_channels elements, "mean" or None, optional
         It describes how to handle input signal channels. If a list, it will
         weight each channel and take the dot product. If "mean",

--- a/niphlem/models.py
+++ b/niphlem/models.py
@@ -204,7 +204,7 @@ class RetroicorPhysio(BasePhysio):
     peak_rise: float
         relative height with respect to the 20th tallest events in signal
         to consider events as peak.
-    order: int or array-like (# TODO) of shape (n_orders,)
+    order: int or array-like of shape (n_orders,)
         Fourier expansion for phases. If int, the fourier expansion is
         performed to that order, starting from 1. If an array is provided,
         each element will multiply the phases.
@@ -283,7 +283,7 @@ class RetroicorPhysio(BasePhysio):
         # Compute peaks in signal
         peaks = compute_max_events(signal, self.peak_rise, self.delta)
 
-        # Correct peaks (TODO: Pass this as argument?)
+        # Correct peaks
         if self.peak_correct:
             peaks, _, _ = correct_anomalies(peaks)
 
@@ -546,7 +546,7 @@ class HVPhysio(BasePhysio):
         # Compute peaks in signal
         peaks = compute_max_events(signal, self.peak_rise, self.delta)
 
-        # Correct peaks (TODO: Pass this as argument?)
+        # Correct peaks
         if self.peak_correct:
             peaks, _, _ = correct_anomalies(peaks)
 


### PR DESCRIPTION
Peaks computed in Retroicor and Variations in Heart Rate can now be corrected using the Outliers procedure included in the library. A new parameter _peak_correct_ has been added to these classes, so that the user may or may not apply this peak correction. The default behaviour is to apply it. I think we can change this in the future to be **always** applied.